### PR TITLE
feat(properties): add update_matrix_property method and refactor SDK checks

### DIFF
--- a/check_sdk.py
+++ b/check_sdk.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import sys
 from typing import Any, Optional
 
 from poelis_sdk import PoelisClient

--- a/check_sdk.py
+++ b/check_sdk.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
-"""Check every SDK method, chaining results from previous calls."""
+"""Check the SDK against live data and/or the local backend schema."""
 
 from __future__ import annotations
 
+import argparse
 import os
 import sys
 from typing import Any, Optional
 
 from poelis_sdk import PoelisClient
+from poelis_sdk._contract_audit import collect_sdk_graphql_documents, validate_sdk_contracts
 
 
 def run(name: str, fn, *args, **kwargs) -> Any:
@@ -27,16 +29,31 @@ def run(name: str, fn, *args, **kwargs) -> Any:
         else:
             print(f"  ✓ {name} → {type(result).__name__}")
         return result
-    except Exception as e:
-        print(f"  ✗ {name} → {type(e).__name__}: {e}")
+    except Exception as exc:
+        print(f"  ✗ {name} → {type(exc).__name__}: {exc}")
         return None
 
 
-def main() -> None:
+def run_contract_audit() -> bool:
+    print("\n=== Contract Audit ===")
+    documents = collect_sdk_graphql_documents()
+    print(f"  ✓ collected {len(documents)} unique GraphQL documents from the SDK surface")
+
+    errors = validate_sdk_contracts()
+    if errors:
+        for error in errors:
+            print(f"  ✗ {error.label} → {error.message}")
+        return False
+
+    print("  ✓ all SDK GraphQL documents validate against the local backend schema")
+    return True
+
+
+def run_live_checks() -> bool:
     api_key = os.environ.get("POELIS_API_KEY")
     if not api_key:
-        print("Set POELIS_API_KEY")
-        sys.exit(1)
+        print("Set POELIS_API_KEY to run live checks")
+        return False
 
     base_url = os.environ.get("POELIS_BASE_URL", "https://poelis-be-py-753618215333.europe-west1.run.app")
     user_id = os.environ.get("POELIS_USER_ID")
@@ -45,6 +62,7 @@ def main() -> None:
     product_id: Optional[str] = None
     item_id: Optional[str] = None
     version_number: Optional[int] = None
+    had_error = False
 
     print("\n=== 1. get_user_accessible_resources ===")
     if not user_id:
@@ -60,13 +78,6 @@ def main() -> None:
         ws_id = resources.workspaces[0].id
         if resources.workspaces[0].products:
             product_id = resources.workspaces[0].products[0].id
-        n_products = 0
-        for ws in resources.workspaces:
-            for p in ws.products:
-                _ = (p.id, p.name, p.role)
-                n_products += 1
-        if n_products > 0:
-            print(f"  ✓ ProductAccess validated ({n_products} products)")
 
     print("\n=== 2. workspaces.list ===")
     workspaces = run("workspaces.list", client.workspaces.list, limit=10, offset=0)
@@ -75,7 +86,8 @@ def main() -> None:
 
     print("\n=== 3. workspaces.get ===")
     if ws_id:
-        run("workspaces.get", client.workspaces.get, workspace_id=ws_id)
+        if run("workspaces.get", client.workspaces.get, workspace_id=ws_id) is None:
+            had_error = True
     else:
         print("  (skipped: no workspace_id from previous steps)")
 
@@ -110,25 +122,9 @@ def main() -> None:
     print("\n=== 6. products.set_product_baseline_version (SKIP - write op) ===")
     print("  (skipped to avoid modifying data)")
 
-    print("\n=== 6b. products.iter_all_by_workspace (first 3) ===")
-    if not ws_id:
-        print("  (skipped: no workspace_id)")
-    elif ws_id:
-        try:
-            count = 0
-            for _ in client.products.iter_all_by_workspace(workspace_id=ws_id, page_size=5):
-                count += 1
-                if count >= 3:
-                    break
-            print(f"  ✓ products.iter_all_by_workspace → yielded {count} products")
-        except Exception as e:
-            print(f"  ✗ products.iter_all_by_workspace → {e}")
-
     print("\n=== 7. items.list_by_product ===")
     items_list = None
-    if not product_id:
-        print("  (skipped: no product_id)")
-    elif product_id:
+    if product_id:
         items_list = run(
             "items.list_by_product",
             client.items.list_by_product,
@@ -138,99 +134,47 @@ def main() -> None:
         )
         if items_list and len(items_list) > 0 and not item_id:
             item_id = items_list[0].get("id")
-
-    print("\n=== 7b. items.iter_all_by_product (first 3) ===")
-    if not product_id:
+    else:
         print("  (skipped: no product_id)")
-    elif product_id:
-        try:
-            count = 0
-            for _ in client.items.iter_all_by_product(product_id=product_id, page_size=5):
-                count += 1
-                if count >= 3:
-                    break
-            print(f"  ✓ items.iter_all_by_product → yielded {count} items")
-        except Exception as e:
-            print(f"  ✗ items.iter_all_by_product → {e}")
-
-    print("\n=== 7c. items.list_by_product (filter q) ===")
-    if not product_id:
-        print("  (skipped: no product_id)")
-    elif product_id:
-        run(
-            "items.list_by_product(q='a')",
-            client.items.list_by_product,
-            product_id=product_id,
-            q="a",
-            limit=10,
-            offset=0,
-        )
 
     print("\n=== 8. items.get ===")
     if item_id:
-        run("items.get", client.items.get, item_id)
+        if run("items.get", client.items.get, item_id) is None:
+            had_error = True
     else:
         print("  (skipped: no item_id)")
 
     print("\n=== 9. versions.list_items ===")
-    if not (product_id and version_number):
-        print("  (skipped: need product_id and version_number)")
-    elif product_id and version_number:
-        run(
+    if product_id and version_number:
+        if run(
             "versions.list_items",
             client.versions.list_items,
             product_id=product_id,
             version_number=version_number,
             limit=10,
             offset=0,
-        )
-
-    print("\n=== 9b. versions.iter_items (first 3) ===")
-    if not (product_id and version_number):
+        ) is None:
+            had_error = True
+    else:
         print("  (skipped: need product_id and version_number)")
-    elif product_id and version_number:
-        try:
-            count = 0
-            for _ in client.versions.iter_items(product_id=product_id, version_number=version_number, page_size=5):
-                count += 1
-                if count >= 3:
-                    break
-            print(f"  ✓ versions.iter_items → yielded {count} items")
-        except Exception as e:
-            print(f"  ✗ versions.iter_items → {e}")
-
-    print("\n=== 9c. versions.list_items (filter q) ===")
-    if not (product_id and version_number):
-        print("  (skipped: need product_id and version_number)")
-    elif product_id and version_number:
-        run(
-            "versions.list_items(q='a')",
-            client.versions.list_items,
-            product_id=product_id,
-            version_number=version_number,
-            q="a",
-            limit=10,
-            offset=0,
-        )
 
     print("\n=== 10. search.products ===")
-    if not ws_id:
-        print("  (skipped: no workspace_id)")
-    elif ws_id:
-        run(
+    if ws_id:
+        if run(
             "search.products",
             client.search.products,
             q="*",
             workspace_id=ws_id,
             limit=10,
             offset=0,
-        )
+        ) is None:
+            had_error = True
+    else:
+        print("  (skipped: no workspace_id)")
 
     print("\n=== 11. search.items ===")
-    if not product_id:
-        print("  (skipped: no product_id)")
-    elif product_id:
-        run(
+    if product_id:
+        if run(
             "search.items",
             client.search.items,
             q=None,
@@ -238,24 +182,13 @@ def main() -> None:
             parent_item_id=None,
             limit=10,
             offset=0,
-        )
-
-    print("\n=== 11b. search.items (filter q, parent_item_id) ===")
-    if not product_id:
+        ) is None:
+            had_error = True
+    else:
         print("  (skipped: no product_id)")
-    elif product_id:
-        run(
-            "search.items(q='a', parent_item_id=item_id)",
-            client.search.items,
-            q="a",
-            product_id=product_id,
-            parent_item_id=item_id,
-            limit=10,
-            offset=0,
-        )
 
     print("\n=== 12. search.properties ===")
-    run(
+    if run(
         "search.properties",
         client.search.properties,
         q="*",
@@ -264,63 +197,74 @@ def main() -> None:
         item_id=item_id,
         limit=10,
         offset=0,
-    )
+    ) is None:
+        had_error = True
 
     print("\n=== 13. properties.update_* (SKIP - write ops) ===")
     print("  (skipped to avoid modifying data)")
 
     print("\n=== 14. browser (navigate workspace → product → item → props) ===")
     ws_name = None
-    has_ws_data = (workspaces and len(workspaces) > 0) or (resources and resources.workspaces)
-    if not has_ws_data:
-        print("  (skipped: no workspace data)")
-    elif workspaces:
+    if workspaces:
         ws_name = workspaces[0].get("readableId") or workspaces[0].get("name") or workspaces[0].get("id")
     elif resources and resources.workspaces:
         ws_name = resources.workspaces[0].name
     if ws_name:
         try:
             ws_node = client.browser[ws_name]
-            print(f"  ✓ browser[{ws_name!r}] → workspace node")
-            prod_names = list(ws_node._children_cache.keys()) if ws_node._children_cache else []
-            if not prod_names and hasattr(ws_node, "_load_children"):
-                ws_node._load_children()
-                prod_names = list(ws_node._children_cache.keys())
-            if prod_names:
-                prod_node = ws_node[prod_names[0]]
-                print("  ✓ browser → product node")
-                baseline = getattr(prod_node, "baseline", None)
-                if baseline:
-                    baseline._load_children()
-                    item_keys = list(baseline._children_cache.keys()) if baseline._children_cache else []
-                    if item_keys:
-                        item_node = baseline[item_keys[0]]
-                        props = item_node._properties() if hasattr(item_node, "_properties") else []
-                        print(f"  ✓ browser → item → {len(props)} props")
-                    else:
-                        print("  ✓ browser → product (no items)")
-                else:
-                    print("  ✓ browser → product (no baseline)")
-        except Exception as e:
-            print(f"  ✗ browser → {e}")
+            prod_node = ws_node[ws_node.list_products().names[0]]
+            item_node = prod_node[prod_node.list_items().names[0]]
+            props = item_node.list_properties().names
+            print(f"  ✓ browser traversal → {len(props)} properties")
+        except Exception as exc:
+            print(f"  ✗ browser → {exc}")
+            had_error = True
+    else:
+        print("  (skipped: no workspace data)")
 
-    print("\n=== 15. browser.list_workspaces ===")
-    run("browser.list_workspaces", client.browser.list_workspaces)
-
-    print("\n=== 16. Client properties ===")
+    print("\n=== 15. Client properties ===")
     print(f"  base_url: {client.base_url}")
     print(f"  org_id: {client.org_id}")
     print(f"  enable_change_detection: {client.enable_change_detection}")
 
-    print("\n=== 17. PoelisClient.from_env ===")
+    print("\n=== 16. PoelisClient.from_env ===")
     try:
         env_client = PoelisClient.from_env()
         print(f"  ✓ from_env → client (base_url={env_client.base_url})")
-    except Exception as e:
-        print(f"  ✗ from_env → {e}")
+    except Exception as exc:
+        print(f"  ✗ from_env → {exc}")
+        had_error = True
 
     print("\n=== Done ===")
+    return not had_error
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--validate-contracts",
+        action="store_true",
+        help="Validate the SDK's GraphQL documents against the sibling backend schema.",
+    )
+    parser.add_argument(
+        "--contracts-only",
+        action="store_true",
+        help="Run only the local contract audit and skip live API checks.",
+    )
+    args = parser.parse_args(argv)
+
+    success = True
+
+    if args.validate_contracts or args.contracts_only:
+        success = run_contract_audit() and success
+
+    if not args.contracts_only:
+        live_success = run_live_checks()
+        if os.environ.get("POELIS_API_KEY"):
+            success = live_success and success
+
+    return 0 if success else 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ extend-exclude = [
 [tool.pytest.ini_options]
 addopts = "-q"
 testpaths = ["tests"]
+markers = [
+    "integration: live SDK checks that require configured Poelis credentials",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/poelis_sdk"]

--- a/src/poelis_matlab/SETUP.md
+++ b/src/poelis_matlab/SETUP.md
@@ -1,0 +1,127 @@
+# Using Poelis from MATLAB
+
+If you already use MATLAB for calculations or simulation, you can call the Poelis Python SDK from MATLAB by pointing MATLAB to a Python environment where `poelis-sdk` is installed and then using the Poelis MATLAB Toolbox helpers.
+
+This setup lets you:
+
+- read values and metadata from Poelis in MATLAB
+- run calculations locally in MATLAB
+- keep Poelis as the source of truth while doing analysis in your own environment
+
+## How It Works
+
+MATLAB talks to Python through `pyenv`. The Poelis MATLAB Toolbox is a thin MATLAB wrapper around the Python SDK. The toolbox gives you MATLAB-friendly helpers such as `poelis_sdk.checkInstallation()` and `poelis_sdk.PoelisClient(...)`, while the actual API calls are handled by the Python package installed in your virtual environment.
+
+## First-Time Setup
+
+### 1. Install the Poelis MATLAB Toolbox
+
+Download the latest `PoelisToolbox-<version>.mltbx` release artifact and install it in MATLAB.
+
+You can either:
+
+- double-click the `.mltbx` file in MATLAB, or
+- run:
+
+```matlab
+matlab.addons.toolbox.installToolbox('PoelisToolbox-1.0.8.mltbx');
+```
+
+### 2. Create a Python Environment and Install `poelis-sdk`
+
+In a terminal:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate   # on Windows: .venv\Scripts\activate
+pip install --upgrade pip
+pip install -U poelis-sdk
+which python                # on Windows: where python
+```
+
+Keep the full path printed by `which python` or `where python`. You will need it in MATLAB.
+
+### 3. Point MATLAB to That Python Environment
+
+In MATLAB:
+
+```matlab
+pyenv('Version', '/full/path/to/.venv/bin/python');   % on Windows: full path to .venv\Scripts\python.exe
+pyenv
+```
+
+If MATLAB is already using another Python interpreter, restart the Python session first:
+
+```matlab
+terminate(pyenv)
+pyenv('Version', '/full/path/to/.venv/bin/python');
+```
+
+### 4. Verify the Setup
+
+In MATLAB:
+
+```matlab
+poelis_sdk.checkInstallation();
+mod = py.importlib.import_module('poelis_sdk');
+char(py.builtins.getattr(mod, '__version__'))
+char(py.builtins.getattr(mod, '__file__'))
+```
+
+You should see:
+
+- the installed `poelis-sdk` version
+- the Python file path inside the environment you configured
+
+### 5. Start Using the SDK
+
+Open `try_poelis_matlab.m`, replace the API key and demo paths with your real ones, and run it.
+
+## Updating an Existing MATLAB Setup
+
+When a new SDK or toolbox version is released, users usually need to update both parts:
+
+### 1. Install the New MATLAB Toolbox
+
+Install the new `PoelisToolbox-<version>.mltbx` file in MATLAB.
+
+```matlab
+matlab.addons.toolbox.installToolbox('PoelisToolbox-1.0.8.mltbx');
+```
+
+If MATLAB asks you to restart after the toolbox update, do that first.
+
+### 2. Upgrade the Python SDK
+
+Activate the same Python environment that MATLAB uses, then run:
+
+```bash
+pip install -U poelis-sdk
+```
+
+### 3. Restart MATLAB's Python Session
+
+In MATLAB:
+
+```matlab
+terminate(pyenv)
+```
+
+If the Python path did not change, MATLAB will usually pick up the same interpreter again on the next Python call. If the Python environment changed, run `pyenv('Version', ...)` again.
+
+### 4. Verify After the Update
+
+In MATLAB:
+
+```matlab
+poelis_sdk.checkInstallation();
+mod = py.importlib.import_module('poelis_sdk');
+char(py.builtins.getattr(mod, '__version__'))
+```
+
+## Troubleshooting
+
+- If MATLAB loads the wrong Python package, check `char(py.builtins.getattr(mod, '__file__'))`.
+- If you change Python environments, run `terminate(pyenv)` before calling `pyenv('Version', ...)` again.
+- If the toolbox is updated but Python is not, MATLAB may still load an older `poelis-sdk`.
+- If Python is updated but the toolbox is not, users may miss MATLAB wrapper fixes or examples from the newer release.

--- a/src/poelis_sdk/_browser/props.py
+++ b/src/poelis_sdk/_browser/props.py
@@ -387,7 +387,7 @@ class _PropWrapper:
             if property_type == "numeric":
                 updated_property = properties_client.update_numeric_property(**mutation_params)
             elif property_type == "matrix":
-                updated_property = properties_client.update_numeric_property(**mutation_params)
+                updated_property = properties_client.update_matrix_property(**mutation_params)
             elif property_type == "text":
                 updated_property = properties_client.update_text_property(**mutation_params)
             elif property_type == "date":
@@ -575,4 +575,3 @@ class _PropWrapper:
             str: The best-effort display name, or an empty string if unknown.
         """
         return self.name or ""
-

--- a/src/poelis_sdk/_contract_audit.py
+++ b/src/poelis_sdk/_contract_audit.py
@@ -1,0 +1,591 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from .browser import Browser
+from .client import PoelisClient
+from .items import ItemsClient
+from .matlab_facade import PoelisMatlab
+from .products import ProductsClient
+from .properties import PropertiesClient
+from .search import SearchClient
+from .versions import VersionsClient
+from .workspaces import WorkspacesClient
+
+
+@dataclass(frozen=True)
+class GraphQLDocument:
+    label: str
+    query: str
+
+
+@dataclass(frozen=True)
+class ContractValidationError:
+    label: str
+    message: str
+
+
+class _MockResponse:
+    def __init__(self, payload: Dict[str, Any]) -> None:
+        self._payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+
+class _RecordingTransport:
+    def __init__(self) -> None:
+        self.documents: list[GraphQLDocument] = []
+
+    def graphql(self, query: str, variables: Optional[Dict[str, Any]] = None) -> _MockResponse:
+        variables = variables or {}
+        self.documents.append(GraphQLDocument(label=self._label_for(query), query=query))
+        return _MockResponse(self._payload_for(query, variables))
+
+    def _label_for(self, query: str) -> str:
+        for marker, label in (
+            ("userAccessibleResources(", "workspaces.get_user_accessible_resources"),
+            ("workspace(", "workspaces.get"),
+            ("workspaces(", "workspaces.list"),
+            ("setProductBaselineVersion(", "products.set_product_baseline_version"),
+            ("productVersions(", "products.list_product_versions"),
+            ("products(", "products.list_by_workspace"),
+            ("sdkItems(", "versions.list_items"),
+            ("items(productId:", "items.list_by_product"),
+            ("item(id:", "items.get"),
+            ("searchProperties(", "search.properties"),
+            ("sdkProperties(", "browser.sdk_properties"),
+            ("properties(itemId:", "browser.properties"),
+            ("updateMatrixProperty(", "properties.update_matrix_property"),
+            ("updateNumericProperty(", "properties.update_numeric_property"),
+            ("updateTextProperty(", "properties.update_text_property"),
+            ("updateDateProperty(", "properties.update_date_property"),
+            ("updateStatusProperty(", "properties.update_status_property"),
+        ):
+            if marker in query:
+                return label
+        return "unknown"
+
+    def _payload_for(self, query: str, variables: Dict[str, Any]) -> Dict[str, Any]:
+        if "userAccessibleResources(" in query:
+            return {
+                "data": {
+                    "userAccessibleResources": [
+                        {
+                            "id": "w1",
+                            "name": "Workspace Main",
+                            "readableId": "workspace_main",
+                            "role": "EDITOR",
+                            "products": [
+                                {
+                                    "id": "p1",
+                                    "name": "Widget Product",
+                                    "readableId": "widget_product",
+                                    "role": "EDITOR",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+
+        if "workspaces(" in query:
+            return {
+                "data": {
+                    "workspaces": [
+                        {
+                            "id": "w1",
+                            "orgId": "org-1",
+                            "name": "Workspace Main",
+                            "readableId": "workspace_main",
+                        }
+                    ]
+                }
+            }
+
+        if "workspace(" in query:
+            return {
+                "data": {
+                    "workspace": {
+                        "id": "w1",
+                        "orgId": "org-1",
+                        "name": "Workspace Main",
+                        "readableId": "workspace_main",
+                    }
+                }
+            }
+
+        if "setProductBaselineVersion(" in query:
+            version_number = variables.get("versionNumber", 2)
+            return {
+                "data": {
+                    "setProductBaselineVersion": {
+                        "id": "p1",
+                        "name": "Widget Product",
+                        "readableId": "widget_product",
+                        "workspaceId": "w1",
+                        "baselineVersionNumber": version_number,
+                        "reviewers": [],
+                    }
+                }
+            }
+
+        if "productVersions(" in query:
+            return {
+                "data": {
+                    "productVersions": [
+                        {
+                            "productId": "p1",
+                            "versionNumber": 2,
+                            "title": "Version 2",
+                            "description": "Current baseline",
+                            "createdAt": "2026-01-01T00:00:00Z",
+                        }
+                    ]
+                }
+            }
+
+        if "products(" in query:
+            offset = int(variables.get("offset", 0))
+            limit = int(variables.get("limit", 100))
+            products = [
+                {
+                    "id": "p1",
+                    "name": "Widget Product",
+                    "readableId": "widget_product",
+                    "workspaceId": "w1",
+                    "baselineVersionNumber": 2,
+                    "reviewers": [],
+                }
+            ]
+            return {
+                "data": {
+                    "products": products[offset:offset + limit]
+                }
+            }
+
+        if "sdkItems(" in query:
+            offset = int(variables.get("offset", 0))
+            limit = int(variables.get("limit", 100))
+            items = [
+                {
+                    "id": "i1",
+                    "name": "Widget Alpha",
+                    "readableId": "widget_alpha",
+                    "productId": "p1",
+                    "parentId": None,
+                    "position": 1,
+                    "deleted": False,
+                }
+            ]
+            return {
+                "data": {
+                    "sdkItems": items[offset:offset + limit]
+                }
+            }
+
+        if "item(id:" in query:
+            return {
+                "data": {
+                    "item": {
+                        "id": "i1",
+                        "name": "Widget Alpha",
+                        "readableId": "widget_alpha",
+                        "productId": "p1",
+                        "parentId": None,
+                        "position": 1,
+                    }
+                }
+            }
+
+        if "items(productId:" in query:
+            offset = int(variables.get("offset", 0))
+            limit = int(variables.get("limit", 100))
+            parent_item_id = (variables.get("filter") or {}).get("parentItemId")
+            items: list[dict[str, Any]]
+            if parent_item_id:
+                items = []
+            else:
+                items = [
+                    {
+                        "id": "i1",
+                        "name": "Widget Alpha",
+                        "readableId": "widget_alpha",
+                        "productId": "p1",
+                        "parentId": None,
+                        "position": 1,
+                    }
+                ]
+            return {"data": {"items": items[offset:offset + limit]}}
+
+        if "searchProperties(" in query:
+            return {
+                "data": {
+                    "searchProperties": {
+                        "query": variables.get("q", "*"),
+                        "hits": [
+                            {
+                                "id": "pn1",
+                                "workspaceId": "w1",
+                                "productId": "p1",
+                                "itemId": "i1",
+                                "propertyType": "numeric",
+                                "name": "Mass",
+                                "category": "MASS",
+                                "value": "12.5",
+                            }
+                        ],
+                        "total": 1,
+                        "limit": variables.get("limit", 20),
+                        "offset": variables.get("offset", 0),
+                        "processingTimeMs": 1,
+                    }
+                }
+            }
+
+        if "sdkProperties(" in query or "properties(itemId:" in query:
+            base_props = [
+                {
+                    "__typename": "NumericProperty",
+                    "id": "pn1",
+                    "name": "Mass",
+                    "readableId": "mass",
+                    "itemId": "i1",
+                    "value": "12.5",
+                    "parsedValue": 12.5,
+                    "category": "MASS",
+                    "displayUnit": "kg",
+                    "deleted": False,
+                    "draftPropertyId": None,
+                    "updatedAt": "2026-01-01T00:00:00Z",
+                    "updatedBy": "sdk@poelis.test",
+                },
+                {
+                    "__typename": "MatrixProperty",
+                    "id": "pm1",
+                    "name": "Mass Matrix",
+                    "readableId": "mass_matrix",
+                    "itemId": "i1",
+                    "value": "[[1, 2], [3, 4]]",
+                    "parsedValue": [[1, 2], [3, 4]],
+                    "category": "MASS",
+                    "displayUnit": "kg",
+                    "deleted": False,
+                    "draftPropertyId": None,
+                    "updatedAt": "2026-01-01T00:00:00Z",
+                    "updatedBy": "sdk@poelis.test",
+                },
+                {
+                    "__typename": "TextProperty",
+                    "id": "pt1",
+                    "name": "Description",
+                    "readableId": "description",
+                    "itemId": "i1",
+                    "value": "Widget",
+                    "parsedValue": "Widget",
+                    "deleted": False,
+                    "draftPropertyId": None,
+                    "updatedAt": "2026-01-01T00:00:00Z",
+                    "updatedBy": "sdk@poelis.test",
+                },
+                {
+                    "__typename": "DateProperty",
+                    "id": "pd1",
+                    "name": "Release Date",
+                    "readableId": "release_date",
+                    "itemId": "i1",
+                    "value": "2026-01-02",
+                    "deleted": False,
+                    "draftPropertyId": None,
+                    "updatedAt": "2026-01-01T00:00:00Z",
+                    "updatedBy": "sdk@poelis.test",
+                },
+                {
+                    "__typename": "StatusProperty",
+                    "id": "ps1",
+                    "name": "Status",
+                    "readableId": "status",
+                    "itemId": "i1",
+                    "value": "DRAFT",
+                    "deleted": False,
+                    "draftPropertyId": None,
+                    "updatedAt": "2026-01-01T00:00:00Z",
+                    "updatedBy": "sdk@poelis.test",
+                },
+                {
+                    "__typename": "FormulaProperty",
+                    "id": "pf1",
+                    "name": "Computed Mass",
+                    "readableId": "computed_mass",
+                    "itemId": "i1",
+                    "numericValue": "42",
+                    "parsedValue": 42,
+                    "formulaExpression": "@{pn1}",
+                    "formulaDependencies": [
+                        {
+                            "id": "pn1",
+                            "name": "Mass",
+                            "value": "12.5",
+                            "displayUnit": "kg",
+                            "itemId": "i1",
+                            "productId": "p1",
+                            "hierarchyContext": [{"id": "i1", "name": "Widget Alpha"}],
+                        }
+                    ],
+                    "hasFormulaDependencyChanges": False,
+                    "deleted": False,
+                    "draftPropertyId": None,
+                    "updatedAt": "2026-01-01T00:00:00Z",
+                    "updatedBy": "sdk@poelis.test",
+                },
+            ]
+            field_name = "sdkProperties" if "sdkProperties(" in query else "properties"
+            return {"data": {field_name: base_props}}
+
+        if "updateNumericProperty(" in query:
+            return {
+                "data": {
+                    "updateNumericProperty": {
+                        "id": variables["id"],
+                        "readableId": "mass",
+                        "itemId": "i1",
+                        "name": "Mass",
+                        "position": 1,
+                        "value": variables.get("value"),
+                        "draftPropertyId": None,
+                        "deleted": False,
+                        "hasChanges": True,
+                        "parsedValue": json.loads(variables.get("value", "0")),
+                        "category": "MASS",
+                        "displayUnit": "kg",
+                    }
+                }
+            }
+
+        if "updateMatrixProperty(" in query:
+            return {
+                "data": {
+                    "updateMatrixProperty": {
+                        "id": variables["id"],
+                        "readableId": "mass_matrix",
+                        "itemId": "i1",
+                        "name": "Mass Matrix",
+                        "position": 2,
+                        "value": variables.get("value"),
+                        "draftPropertyId": None,
+                        "deleted": False,
+                        "hasChanges": True,
+                        "parsedValue": json.loads(variables.get("value", "[]")),
+                        "category": "MASS",
+                        "displayUnit": "kg",
+                    }
+                }
+            }
+
+        if "updateTextProperty(" in query:
+            return {
+                "data": {
+                    "updateTextProperty": {
+                        "id": variables["id"],
+                        "readableId": "description",
+                        "itemId": "i1",
+                        "name": "Description",
+                        "position": 3,
+                        "value": variables.get("value"),
+                        "draftPropertyId": None,
+                        "deleted": False,
+                        "hasChanges": True,
+                        "parsedValue": variables.get("value"),
+                    }
+                }
+            }
+
+        if "updateDateProperty(" in query:
+            return {
+                "data": {
+                    "updateDateProperty": {
+                        "id": variables["id"],
+                        "readableId": "release_date",
+                        "itemId": "i1",
+                        "name": "Release Date",
+                        "position": 4,
+                        "value": variables.get("value"),
+                        "draftPropertyId": None,
+                        "deleted": False,
+                        "hasChanges": True,
+                    }
+                }
+            }
+
+        if "updateStatusProperty(" in query:
+            return {
+                "data": {
+                    "updateStatusProperty": {
+                        "id": variables["id"],
+                        "readableId": "status",
+                        "itemId": "i1",
+                        "name": "Status",
+                        "position": 5,
+                        "value": variables.get("value"),
+                        "draftPropertyId": None,
+                        "deleted": False,
+                        "hasChanges": True,
+                    }
+                }
+            }
+
+        return {"data": {}}
+
+
+def _configure_client(transport: _RecordingTransport, *, enable_sdk_properties: bool = False) -> PoelisClient:
+    client = PoelisClient(
+        api_key="contract-audit",
+        base_url="http://example.com",
+        enable_change_detection=False,
+    )
+    client._transport = transport
+    client.workspaces = WorkspacesClient(transport)
+    client.products = ProductsClient(transport, client.workspaces)
+    client.items = ItemsClient(transport)
+    client.versions = VersionsClient(transport)
+    client.properties = PropertiesClient(transport)
+    client.search = SearchClient(transport)
+    client.browser = Browser(client)
+    if enable_sdk_properties:
+        client._change_tracker.enable()
+    return client
+
+
+def collect_sdk_graphql_documents() -> List[GraphQLDocument]:
+    transport = _RecordingTransport()
+    client = _configure_client(transport)
+
+    client.workspaces.list(limit=1, offset=0)
+    client.workspaces.get(workspace_id="w1")
+    client.workspaces.get_user_accessible_resources(user_id="user-1")
+
+    client.products.list_by_workspace(workspace_id="w1", q="widget", limit=1, offset=0)
+    client.products.list_product_versions(product_id="p1")
+    client.products.set_product_baseline_version(product_id="p1", version_number=2)
+    list(client.products.iter_all_by_workspace(workspace_id="w1", q="widget", page_size=1))
+    list(client.products.iter_all(q="widget", page_size=1))
+
+    client.items.list_by_product(product_id="p1", q="alpha", limit=1, offset=0)
+    client.items.get("i1")
+    list(client.items.iter_all_by_product(product_id="p1", q="alpha", page_size=1))
+
+    client.versions.list_items(product_id="p1", version_number=2, q="alpha", limit=1, offset=0)
+    list(client.versions.iter_items(product_id="p1", version_number=2, q="alpha", page_size=1))
+
+    client.search.products(q="widget", workspace_id="w1", limit=1, offset=0)
+    client.search.items(q="alpha", product_id="p1", parent_item_id="i1", limit=1, offset=0)
+    client.search.properties(
+        q="*",
+        workspace_id="w1",
+        product_id="p1",
+        item_id="i1",
+        property_type="numeric",
+        category="mass",
+        limit=1,
+        offset=0,
+        sort="updated_at",
+    )
+
+    client.properties.update_numeric_property(id="pn1", value="123.5", changed_via="PYTHON_SDK")
+    client.properties.update_matrix_property(id="pm1", value="[[1, 2], [3, 4]]", changed_via="PYTHON_SDK")
+    client.properties.update_text_property(id="pt1", value="Updated text", changed_via="PYTHON_SDK")
+    client.properties.update_date_property(id="pd1", value="2026-02-01", changed_via="PYTHON_SDK")
+    client.properties.update_status_property(id="ps1", value="DONE", changed_via="PYTHON_SDK")
+
+    workspace = client.browser["workspace_main"]
+    product = workspace["widget_product"]
+    baseline_item = product["widget_alpha"]
+    _ = baseline_item.list_properties().names
+    _ = baseline_item.mass.value
+    _ = product.draft["widget_alpha"].list_items().names
+
+    sdk_transport = _RecordingTransport()
+    sdk_client = _configure_client(sdk_transport, enable_sdk_properties=True)
+    sdk_workspace = sdk_client.browser["workspace_main"]
+    sdk_product = sdk_workspace["widget_product"]
+    sdk_item = sdk_product["widget_alpha"]
+    _ = sdk_item.list_properties().names
+    _ = sdk_item.mass.value
+
+    matlab = PoelisMatlab.__new__(PoelisMatlab)
+    matlab.client = client
+    matlab.get_value("workspace_main.widget_product.widget_alpha.mass")
+    matlab.get_property("workspace_main.widget_product.widget_alpha.description")
+    matlab.list_children("workspace_main")
+    matlab.list_properties("workspace_main.widget_product.widget_alpha")
+    matlab.change_property("workspace_main.widget_product.draft.widget_alpha.description", "Updated text")
+
+    return _dedupe_documents([*transport.documents, *sdk_transport.documents])
+
+
+def _dedupe_documents(documents: Iterable[GraphQLDocument]) -> List[GraphQLDocument]:
+    seen: set[str] = set()
+    unique: list[GraphQLDocument] = []
+    for document in documents:
+        normalized = "\n".join(line.rstrip() for line in document.query.strip().splitlines())
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        unique.append(GraphQLDocument(label=document.label, query=normalized))
+    return unique
+
+
+def backend_repo_root() -> Path:
+    return Path(__file__).resolve().parents[3] / "poelis-be-py"
+
+
+def backend_python() -> Path:
+    return backend_repo_root() / ".venv" / "bin" / "python"
+
+
+def validate_sdk_contracts() -> list[ContractValidationError]:
+    python_bin = backend_python()
+    if not python_bin.exists():
+        raise FileNotFoundError(f"Backend Python not found at {python_bin}")
+
+    script = """
+import json
+import sys
+
+sys.path.insert(0, "src")
+
+from graphql import parse, validate
+from poelis.api.graphql.schema import schema
+
+documents = json.load(sys.stdin)
+errors = []
+for document in documents:
+    for error in validate(schema._schema, parse(document["query"])):
+        errors.append({"label": document["label"], "message": str(error)})
+
+json.dump(errors, sys.stdout)
+"""
+
+    completed = subprocess.run(
+        [str(python_bin), "-c", script],
+        input=json.dumps(
+            [{"label": document.label, "query": document.query} for document in collect_sdk_graphql_documents()]
+        ),
+        text=True,
+        cwd=backend_repo_root(),
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or completed.stdout.strip() or "Contract validation failed")
+
+    payload = json.loads(completed.stdout or "[]")
+    return [ContractValidationError(label=error["label"], message=error["message"]) for error in payload]

--- a/src/poelis_sdk/properties.py
+++ b/src/poelis_sdk/properties.py
@@ -292,6 +292,125 @@ class PropertiesClient:
 
         return property_data
 
+    def update_matrix_property(
+        self,
+        *,
+        id: str,  # noqa: A002
+        value: Optional[str] = None,
+        item_id: Optional[str] = None,
+        name: Optional[str] = None,
+        readable_id: Optional[str] = None,
+        position: Optional[float] = None,
+        category: Optional[str] = None,
+        display_unit: Optional[str] = None,
+        reason: Optional[str] = None,
+        description: Optional[str] = None,
+        changed_via: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Update a matrix property via GraphQL mutation."""
+        if changed_via is not None:
+            mutation = (
+                "mutation UpdateMatrixProperty($id: ID!, $itemId: ID, $name: String, $readableId: String, "
+                "$position: Float, $value: String, $category: String, $displayUnit: String, "
+                "$reason: String, $description: String, $changedVia: ChangedVia) {\n"
+                "  updateMatrixProperty(\n"
+                "    id: $id\n"
+                "    itemId: $itemId\n"
+                "    name: $name\n"
+                "    readableId: $readableId\n"
+                "    position: $position\n"
+                "    value: $value\n"
+                "    category: $category\n"
+                "    displayUnit: $displayUnit\n"
+                "    reason: $reason\n"
+                "    description: $description\n"
+                "    changedVia: $changedVia\n"
+                "  ) {\n"
+                "    id\n"
+                "    readableId\n"
+                "    itemId\n"
+                "    name\n"
+                "    position\n"
+                "    value\n"
+                "    draftPropertyId\n"
+                "    deleted\n"
+                "    hasChanges\n"
+                "    parsedValue\n"
+                "    category\n"
+                "    displayUnit\n"
+                "  }\n"
+                "}"
+            )
+        else:
+            mutation = (
+                "mutation UpdateMatrixProperty($id: ID!, $itemId: ID, $name: String, $readableId: String, "
+                "$position: Float, $value: String, $category: String, $displayUnit: String, "
+                "$reason: String, $description: String) {\n"
+                "  updateMatrixProperty(\n"
+                "    id: $id\n"
+                "    itemId: $itemId\n"
+                "    name: $name\n"
+                "    readableId: $readableId\n"
+                "    position: $position\n"
+                "    value: $value\n"
+                "    category: $category\n"
+                "    displayUnit: $displayUnit\n"
+                "    reason: $reason\n"
+                "    description: $description\n"
+                "  ) {\n"
+                "    id\n"
+                "    readableId\n"
+                "    itemId\n"
+                "    name\n"
+                "    position\n"
+                "    value\n"
+                "    draftPropertyId\n"
+                "    deleted\n"
+                "    hasChanges\n"
+                "    parsedValue\n"
+                "    category\n"
+                "    displayUnit\n"
+                "  }\n"
+                "}"
+            )
+
+        variables: Dict[str, Any] = {"id": id}
+        if item_id is not None:
+            variables["itemId"] = item_id
+        if name is not None:
+            variables["name"] = name
+        if readable_id is not None:
+            variables["readableId"] = readable_id
+        if position is not None:
+            variables["position"] = position
+        if value is not None:
+            variables["value"] = value
+        if category is not None:
+            variables["category"] = category
+        if display_unit is not None:
+            variables["displayUnit"] = display_unit
+        if reason is not None:
+            variables["reason"] = reason
+        if description is not None:
+            variables["description"] = description
+        if changed_via is not None:
+            variables["changedVia"] = changed_via
+
+        resp = self._t.graphql(query=mutation, variables=variables)
+        resp.raise_for_status()
+        payload = resp.json()
+
+        if "errors" in payload:
+            self._handle_graphql_errors(payload["errors"])
+
+        property_data = payload.get("data", {}).get("updateMatrixProperty")
+        if property_data is None:
+            if "errors" in payload:
+                self._handle_graphql_errors(payload["errors"])
+            raise RuntimeError("Malformed GraphQL response: missing 'updateMatrixProperty' field")
+
+        return property_data
+
     def update_date_property(
         self,
         *,
@@ -641,4 +760,3 @@ class PropertiesClient:
         if value not in valid_statuses:
             raise ValueError(f"Status must be one of: DRAFT, UNDER_REVIEW, DONE. Got: {value}")
         return value
-

--- a/src/poelis_sdk/properties.py
+++ b/src/poelis_sdk/properties.py
@@ -307,7 +307,24 @@ class PropertiesClient:
         description: Optional[str] = None,
         changed_via: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Update a matrix property via GraphQL mutation."""
+        """Update a matrix property via GraphQL mutation.
+
+        Args:
+            id: Property ID (required).
+            value: New matrix value as a JSON string.
+            item_id: Optional item ID to move property to.
+            name: Optional property name.
+            readable_id: Optional readable ID.
+            position: Optional position for ordering.
+            category: Optional category (auto-normalized by the backend).
+            display_unit: Optional display unit.
+            reason: Optional reason for history tracking.
+            description: Optional description for history tracking.
+            changed_via: Optional source of the change.
+
+        Returns:
+            Dict[str, Any]: Updated property object from backend.
+        """
         if changed_via is not None:
             mutation = (
                 "mutation UpdateMatrixProperty($id: ID!, $itemId: ID, $name: String, $readableId: String, "

--- a/tests/test_graphql_contracts.py
+++ b/tests/test_graphql_contracts.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from poelis_sdk._contract_audit import (
+    backend_repo_root,
+    collect_sdk_graphql_documents,
+    validate_sdk_contracts,
+)
+
+
+def test_contract_audit_collects_expected_documents() -> None:
+    """Ensure the audit exercises the split property mutations and browser reads."""
+    documents = collect_sdk_graphql_documents()
+    queries = [document.query for document in documents]
+
+    assert any("updateMatrixProperty" in query for query in queries)
+    assert any("updateNumericProperty" in query for query in queries)
+    assert any("sdkProperties" in query for query in queries)
+    assert any("searchProperties" in query for query in queries)
+
+
+def test_sdk_graphql_documents_validate_against_backend_schema() -> None:
+    """All SDK-emitted GraphQL documents should remain valid against the backend schema."""
+    backend_root = backend_repo_root()
+    if not (backend_root / "src").exists():
+        pytest.skip(f"Backend repo not found at {backend_root}")
+
+    errors = validate_sdk_contracts()
+    assert not errors, "\n".join(f"{error.label}: {error.message}" for error in errors)

--- a/tests/test_property_writes.py
+++ b/tests/test_property_writes.py
@@ -140,6 +140,42 @@ def test_change_property_numeric_array(mock_client: PoelisClient) -> None:
     assert variables["value"] == "[4, 5, 6]"  # Should be JSON string
 
 
+def test_change_property_matrix_value_uses_matrix_mutation(mock_client: PoelisClient) -> None:
+    """Matrix properties must use the dedicated backend mutation."""
+    raw_prop: Dict[str, Any] = {
+        "id": "prop-m1",
+        "__typename": "MatrixProperty",
+        "readableId": "mass_matrix",
+        "value": "[[1, 2], [3, 4]]",
+        "parsedValue": [[1, 2], [3, 4]],
+        "category": "Mass",
+        "displayUnit": "kg",
+        "productVersionNumber": None,
+    }
+
+    updated_prop = {
+        "id": "prop-m1",
+        "readableId": "mass_matrix",
+        "value": "[[5, 6], [7, 8]]",
+        "parsedValue": [[5, 6], [7, 8]],
+        "category": "Mass",
+        "displayUnit": "kg",
+        "type": "matrix",
+    }
+    mock_client._transport.set_response({"data": {"updateMatrixProperty": updated_prop}})  # type: ignore[attr-defined]
+
+    wrapper = _PropWrapper(raw_prop, client=mock_client)
+    wrapper.change_property([[5, 6], [7, 8]])
+
+    request = mock_client._transport.requests[0]  # type: ignore[attr-defined]
+    variables = request["variables"]
+
+    assert variables["id"] == "prop-m1"
+    assert variables["value"] == "[[5, 6], [7, 8]]"
+    assert "updateMatrixProperty" in request["query"]
+    assert "updateNumericProperty" not in request["query"]
+
+
 def test_change_property_text_value(mock_client: PoelisClient) -> None:
     """Test updating text property value."""
     raw_prop: Dict[str, Any] = {
@@ -257,6 +293,23 @@ def test_change_property_status_invalid_value(mock_client: PoelisClient) -> None
 
     with pytest.raises(ValueError, match="Status must be one of"):
         wrapper.change_property("INVALID_STATUS")
+
+
+def test_change_property_formula_value_is_rejected(mock_client: PoelisClient) -> None:
+    """Formula properties remain read-only after the numeric/matrix split."""
+    raw_prop: Dict[str, Any] = {
+        "id": "prop-f1",
+        "__typename": "FormulaProperty",
+        "readableId": "computed_mass",
+        "value": "42",
+        "formulaExpression": "@{dep-1}",
+        "productVersionNumber": None,
+    }
+
+    wrapper = _PropWrapper(raw_prop, client=mock_client)
+
+    with pytest.raises(ValueError, match="Formula properties cannot be updated"):
+        wrapper.change_property(99)
 
 
 def test_change_property_versioned_property(mock_client: PoelisClient) -> None:


### PR DESCRIPTION
Implemented the SDK-side fixes for ENG-417 in poelis-python-sdk.

  The main functional change is that matrix properties now follow the backend refactor correctly: the SDK has a dedicated update_matrix_property(...) method in
  poelis-python-sdk/src/poelis_sdk/properties.py, and browser/MATLAB writes in poelis-python-sdk/src/poelis_sdk/_browser/props.py now dispatch matrix updates to
  updateMatrixProperty instead of incorrectly reusing the numeric mutation. Formula properties remain read-only.

  I also added a backend-contract audit path so the SDK can validate its actual GraphQL documents against the sibling backend schema. That lives in poelis-
  python-sdk/src/poelis_sdk/_contract_audit.py and is exposed through poelis-python-sdk/check_sdk.py via --validate-contracts --contracts-only. The audit
  collects the SDK’s real emitted queries and mutations across the client, browser, and MATLAB facade and validates them using the backend repo’s own .venv, so
  it catches drift against the current backend schema without requiring live credentials.

  On the test side, I extended poelis-python-sdk/tests/test_property_writes.py to cover matrix write dispatch and formula write rejection, added poelis-python-
  sdk/tests/test_graphql_contracts.py for schema contract validation, and registered the integration marker in poelis-python-sdk/pyproject.toml to remove the
  pytest warning.

  Verification I ran:
  ./.venv/bin/pytest -q src/tests tests
  ./.venv/bin/python check_sdk.py --validate-contracts --contracts-only