### PR TITLE
chore: bump SDK version to 1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "poelis-sdk"
-version = "1.1.0"
+version = "1.2.0"
 description = "Official Python SDK for Poelis"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/poelis_matlab/toolbox.prj
+++ b/src/poelis_matlab/toolbox.prj
@@ -2,7 +2,7 @@
 <project>
     <metadata>
         <name>Poelis MATLAB Toolbox</name>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
         <author>Michele Genoni</author>
         <email>michele@poelis.com</email>
         <company>Poelis Technologies</company>


### PR DESCRIPTION
## Summary
- Bump `poelis-sdk` from `1.1.0` → `1.2.0` in `pyproject.toml` and matching MATLAB `toolbox.prj`.

DONT MERGE BEFORE https://github.com/PoelisTechnologies/poelis-be-py/pull/888

- [ ] After merge, confirm publish workflow runs and creates `v1.2.0` + PyPI + Release + `.mltbx` asset