### PR TITLE
docs: mention ADMIN workspace role (ENG-786)

### DIFF
--- a/src/poelis_sdk/_browser/_graphql_errors.py
+++ b/src/poelis_sdk/_browser/_graphql_errors.py
@@ -40,7 +40,7 @@ def handle_graphql_read_errors(errors: list[dict[str, Any]]) -> None:
         enhanced_message = (
             f"{error_message}. "
             "You do not have access to this workspace or product. "
-            "Access is determined by your role (EDITOR, VIEWER, or NO_ACCESS). "
+            "Access is determined by your role (ADMIN, EDITOR, VIEWER, or NO_ACCESS). "
             "Contact your administrator if you need access."
         )
         raise UnauthorizedError(403, message=enhanced_message)

--- a/src/poelis_sdk/models.py
+++ b/src/poelis_sdk/models.py
@@ -328,7 +328,7 @@ class ProductAccess(BaseModel):
     id: str = Field(min_length=1)
     name: str = Field(min_length=1)
     readable_id: Optional[str] = Field(alias="readableId", default=None)
-    role: str = Field(min_length=1)  # Role enum: EDITOR, VIEWER, NO_ACCESS, etc.
+    role: str = Field(min_length=1)  # Role enum: ADMIN, EDITOR, VIEWER, NO_ACCESS, etc.
 
 
 class WorkspaceWithProducts(BaseModel):
@@ -347,7 +347,7 @@ class WorkspaceWithProducts(BaseModel):
     id: str = Field(min_length=1)
     name: str = Field(min_length=1)
     readable_id: Optional[str] = Field(alias="readableId", default=None)
-    role: str = Field(min_length=1)  # Role enum: EDITOR, VIEWER, etc.
+    role: str = Field(min_length=1)  # Role enum: ADMIN, EDITOR, VIEWER, etc.
     products: List[ProductAccess] = Field(default_factory=list)
 
 

--- a/src/poelis_sdk/properties.py
+++ b/src/poelis_sdk/properties.py
@@ -705,7 +705,7 @@ class PropertiesClient:
             # Enhanced error message for permission issues
             enhanced_message = (
                 f"{error_message}. "
-                "Write operations require EDITOR role for the workspace or product. "
+                "Write operations require ADMIN or EDITOR role for the workspace or product. "
                 "Users with VIEWER role can only read data."
             )
             raise UnauthorizedError(403, message=enhanced_message)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Doc-only update for ENG-786: include `ADMIN` in the SDK role vocabulary comments and forbidden-access messaging. No API surface changes.

## Test plan

- [ ] N/A (docs only)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f844a-a26a-765e-b4ce-23a7f236d472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f844a-a26a-765e-b4ce-23a7f236d472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

